### PR TITLE
feat : 로그인 및 회원가입 API 연동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import {
   useLocation,
 } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";
+import { AuthProvider } from "./contexts/AuthContext";
 import Home from "./pages/Home/Home.jsx";
 import PromptPage from "./pages/PromptPage/PromptPage.jsx";
 import SignUp from "./pages/SignUp/SignUp.jsx";
@@ -13,6 +14,7 @@ import ProfilePage from "./pages/ProfilePage/ProfilePage.jsx";
 import ReservationsPage from "./pages/ReservationsPage/ReservationsPage.jsx";
 import HistoryPage from "./pages/HistoryPage/HistoryPage.jsx";
 import AnalysisPage from "./pages/AnalysisPage/AnalysisPage.jsx";
+import KakaoCallback from "./pages/Auth/KakaoCallback.jsx";
 // 차후 삭제 필요
 import CarListPage from "./pages/CarListPage/CarListPage";
 // 차후 삭제 필요
@@ -39,7 +41,7 @@ function App() {
 
 
   return (
-    <>
+    <AuthProvider>
       <div className="main-content">
         <Routes>
           <Route path="/" element={<Home />} />
@@ -56,12 +58,16 @@ function App() {
           <Route path="/history" element={<HistoryPage />} />
           <Route path="/analysis" element={<AnalysisPage />} />
           <Route path="/cars" element={<CarListPage />} />
+          <Route path="/auth/kakao/callback" element={<KakaoCallback />} />
         </Routes>
       </div>
       {isSignUpOpen && (
-        <SignUp isOpen={isSignUpOpen} onClose={() => setIsSignUpOpen(false)} />
+        <SignUp isOpen={isSignUpOpen} onClose={() => setIsSignUpOpen(false)} onSwitchLogin={() => {
+          setIsSignUpOpen(false);
+          setIsLoginOpen(true);
+        }} />
       )}
-    </>
+    </AuthProvider>
   );
 }
 

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,74 @@
+import React, { createContext, useState, useEffect, useContext } from 'react';
+import api from '../utils/api';
+
+const AuthContext = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  
+  // 토큰이 있으면 사용자 정보 가져오기
+  useEffect(() => {
+    const checkAuth = async () => {
+      const token = localStorage.getItem('token');
+      
+      if (token) {
+        try {
+          // 사용자 정보 가져오기
+          const response = await api.get('/api/v1/users/me');
+          setUser(response.data);
+        } catch (error) {
+          console.error('인증 확인 오류:', error);
+          // 토큰이 유효하지 않으면 로그아웃
+          logout();
+        }
+      }
+      
+      setLoading(false);
+    };
+    
+    checkAuth();
+  }, []);
+  
+  // 로그아웃 함수
+  const logout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('autoLogin');
+    setUser(null);
+  };
+  
+  // API 요청 인터셉터 설정
+  useEffect(() => {
+    // 응답 인터셉터
+    const interceptor = api.interceptors.response.use(
+      response => response,
+      error => {
+        // 401 Unauthorized 오류 시 로그아웃
+        if (error.response && error.response.status === 401) {
+          logout();
+        }
+        return Promise.reject(error);
+      }
+    );
+    
+    return () => {
+      // 컴포넌트 언마운트 시 인터셉터 제거
+      api.interceptors.response.eject(interceptor);
+    };
+  }, []);
+  
+  return (
+    <AuthContext.Provider value={{ user, loading, logout, setUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+// 커스텀 훅
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/src/pages/Auth/KakaoCallback.jsx
+++ b/src/pages/Auth/KakaoCallback.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import api from '../../utils/api';
+
+const KakaoCallback = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [error, setError] = useState(null);
+  const { setUser } = useAuth();
+
+  useEffect(() => {
+    const processKakaoLogin = async () => {
+      // URL에서 토큰과 사용자 정보 추출
+      const params = new URLSearchParams(location.search);
+      const token = params.get('token');
+      const isNewUser = params.get('isNewUser') === 'true';
+      const userId = params.get('userId');
+      
+      if (!token) {
+        setError('인증 토큰이 없습니다.');
+        return;
+      }
+
+      try {
+        // 토큰 저장
+        localStorage.setItem('token', token);
+        
+        // 사용자 정보 가져오기
+        const response = await api.get('/api/v1/users/me');
+        setUser(response.data);
+        
+        // 로그인 성공 후 리다이렉트
+        if (isNewUser) {
+          navigate('/welcome'); // 신규 사용자 환영 페이지
+        } else {
+          navigate('/'); // 메인 페이지
+        }
+      } catch (err) {
+        console.error('카카오 로그인 처리 중 오류:', err);
+        setError('로그인 처리 중 오류가 발생했습니다.');
+      }
+    };
+
+    processKakaoLogin();
+  }, [location, navigate, setUser]);
+
+  if (error) {
+    return <div className="error-container">{error}</div>;
+  }
+
+  return <div className="loading-container">로그인 처리 중...</div>;
+};
+
+export default KakaoCallback;

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import api from '../../utils/api';
 import './Login.css';
 import { SiNaver } from 'react-icons/si';
 import { FcGoogle } from 'react-icons/fc';
@@ -9,6 +11,7 @@ import ErrorPopup from '../../components/ErrorPopup/ErrorPopup';
 
 const Login = ({ isOpen, onClose, onSwitchSignUp }) => {
   const navigate = useNavigate();
+  const { setUser } = useAuth();
   const [form, setForm] = useState({
     loginId: '',
     password: '',
@@ -16,6 +19,7 @@ const Login = ({ isOpen, onClose, onSwitchSignUp }) => {
   });
   const [error, setError] = useState(null);
   const [passwordVisible, setPasswordVisible] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleInputChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -25,23 +29,77 @@ const Login = ({ isOpen, onClose, onSwitchSignUp }) => {
     }));
   };
 
-  const handleLogin = (e) => {
+  const handleLogin = async (e) => {
     e.preventDefault();
-    // TODO: 로그인 처리 로직
-    setError('로그인 실패!');  // 무조건 오류 발생 차후 수정하셈
+    
+    if (!form.loginId || !form.password) {
+      setError('아이디와 비밀번호를 입력해주세요.');
+      return;
+    }
+    
+    setIsLoading(true);
+    setError(null);
+    
+    try {
+      // 백엔드 로그인 API 호출
+      const response = await api.post('/api/v1/auth/login', {
+        loginId: form.loginId,
+        password: form.password
+      });
+      
+      // 로그인 성공 시 JWT 토큰 저장
+      const { token, user } = response.data;
+      localStorage.setItem('token', token);
+      
+      // 사용자 정보 설정
+      setUser(user);
+      
+      // 자동 로그인 설정 저장
+      if (form.autoLogin) {
+        localStorage.setItem('autoLogin', 'true');
+      } else {
+        localStorage.removeItem('autoLogin');
+      }
+      
+      // 로그인 성공 후 모달 닫기 및 페이지 이동
+      onClose();
+      navigate('/');
+      
+    } catch (err) {
+      console.error('로그인 오류:', err);
+      
+      // 오류 메시지 설정
+      if (err.response) {
+        // 서버에서 응답이 왔지만 오류 상태 코드인 경우
+        if (err.response.status === 401) {
+          setError('아이디 또는 비밀번호가 일치하지 않습니다.');
+        } else {
+          setError(err.response.data?.message || '로그인 처리 중 오류가 발생했습니다.');
+        }
+      } else if (err.request) {
+        // 요청이 전송되었지만 응답이 없는 경우
+        setError('서버와 통신할 수 없습니다. 네트워크 연결을 확인해주세요.');
+      } else {
+        // 요청 설정 중 오류가 발생한 경우
+        setError('로그인 요청 중 오류가 발생했습니다.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleSocialLogin = (provider) => {
-    // TODO: 소셜로그인 
-    localStorage.setItem('token', 'social-login-token');
-    onClose();
+    if (provider === 'kakao') {
+      // 카카오 로그인 URL로 리다이렉트
+      const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID || '7c13edee67bab4b026ddc1256ec88eeb';
+      const REDIRECT_URI = encodeURIComponent('http://localhost:8080/api/v1/auth/kakao/callback');
+      window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+    }
   };
 
-  const socialProviders = [
-    { key: 'kakao', icon: <RiKakaoTalkFill className="kakao-icon" />, className: 'kakao' },
-    { key: 'google', icon: <FcGoogle />, className: 'google' },
-    { key: 'naver', icon: <SiNaver />, className: 'naver' },
-  ];
+  const togglePasswordVisibility = () => {
+    setPasswordVisible(!passwordVisible);
+  };
 
   if (!isOpen) return null;
 
@@ -53,67 +111,79 @@ const Login = ({ isOpen, onClose, onSwitchSignUp }) => {
         <form className="login-form" onSubmit={handleLogin} autoComplete="off">
           <div className="login-form-group">
             <label htmlFor="loginId">아이디</label>
-            <input
-              type="text"
-              name="loginId"
-              id="loginId"
-              value={form.loginId}
-              onChange={handleInputChange}
-              placeholder="아이디를 입력하세요"
-              required
-              className="login-form-underline"
+            <input 
+              type="text" 
+              id="loginId" 
+              name="loginId" 
+              value={form.loginId} 
+              onChange={handleInputChange} 
+              placeholder="아이디를 입력하세요" 
+              required 
             />
           </div>
           <div className="login-form-group">
-            <label htmlFor="login-password">비밀번호</label>
-            <div className="password-input-wrapper">
-              <input
-                type={passwordVisible ? 'text' : 'password'}
-                name="password"
-                id="login-password"
-                value={form.password}
-                onChange={handleInputChange}
-                placeholder="비밀번호를 입력하세요"
-                required
-                className="login-form-underline"
+            <label htmlFor="password">비밀번호</label>
+            <div className="password-input-container">
+              <input 
+                type={passwordVisible ? "text" : "password"} 
+                id="password" 
+                name="password" 
+                value={form.password} 
+                onChange={handleInputChange} 
+                placeholder="비밀번호를 입력하세요" 
+                required 
               />
-              <button
-                type="button"
-                className="password-toggle"
-                onClick={() => setPasswordVisible(v => !v)}
-                tabIndex={-1}
-                aria-label={passwordVisible ? '비밀번호 숨기기' : '비밀번호 보기'}
+              <button 
+                type="button" 
+                className="password-toggle-button" 
+                onClick={togglePasswordVisibility}
               >
                 {passwordVisible ? <MdVisibilityOff /> : <MdVisibility />}
               </button>
             </div>
           </div>
-          <div className="login-options-row">
-            <label className="auto-login">
-              <input type="checkbox" name="autoLogin" checked={form.autoLogin} onChange={handleInputChange} />
-              자동로그인
-            </label>
-            <button type="button" className="find-password" onClick={() => navigate('/find-password')}>비밀번호를 잊으셨나요?</button>
+          <div className="login-options">
+            <div className="auto-login">
+              <input 
+                type="checkbox" 
+                id="autoLogin" 
+                name="autoLogin" 
+                checked={form.autoLogin} 
+                onChange={handleInputChange} 
+              />
+              <label htmlFor="autoLogin">자동 로그인</label>
+            </div>
+            <button type="button" className="forgot-password">비밀번호 찾기</button>
           </div>
-          <button className="login-button" type="submit">로그인하기</button>
+          <button 
+            className="login-button" 
+            type="submit" 
+            disabled={isLoading}
+          >
+            {isLoading ? '로그인 중...' : '로그인하기'}
+          </button>
+          <div className="social-login-title">소셜로그인으로 함께하기</div>
+          <div className="social-login social-row">
+            {[
+              { key: 'kakao', icon: <RiKakaoTalkFill className="kakao-icon" />, className: 'kakao' },
+              { key: 'google', icon: <FcGoogle />, className: 'google' },
+              { key: 'naver', icon: <SiNaver />, className: 'naver' },
+            ].map(({ key, icon, className }) => (
+              <button
+                key={key}
+                className={`social-button ${className}`}
+                type="button"
+                onClick={() => handleSocialLogin(key)}
+              >
+                {icon}
+              </button>
+            ))}
+          </div>
+          <div className="login-divider" />
         </form>
-        <div className="social-login-title">소셜로그인으로 함께하기</div>
-        <div className="social-login social-row">
-          {socialProviders.map(({ key, icon, className }) => (
-            <button
-              key={key}
-              className={`social-button ${className}`}
-              type="button"
-              onClick={() => handleSocialLogin(key)}
-            >
-              {icon}
-            </button>
-          ))}
-        </div>
-        <div className="login-divider" />
         <div className="signup-link-row">
-          <span>CARA 가 처음이신가요?</span>
-          <button className="signup-link" type="button" onClick={onSwitchSignUp}>회원가입 하기</button>
+          <span>아직 회원이 아니신가요?</span>
+          <button className="signup-link" type="button" onClick={onSwitchSignUp}>회원가입하러가기</button>
         </div>
         <ErrorPopup error={error} onClose={() => setError(null)} />
       </div>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,26 @@
+import axios from 'axios';
+
+// axios 인스턴스 생성
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json',
+  }
+});
+
+// 요청 인터셉터
+api.interceptors.request.use(
+  config => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+    return config;
+  },
+  error => {
+    return Promise.reject(error);
+  }
+);
+
+export default api;


### PR DESCRIPTION
1. 카카오 로그인 연동
- Login.jsx 및 Signup.jsx에서 카카오 로그인 버튼 클릭시 카카오 인증 페이지로 리다이렉트
- 카카오 인증 요청 시 필요한 클라이언트 ID와 리다이렉트 URI 설정
- 불필요 kakaoURL 변수 제거하여 코드 최적화

2. 카카오 OAuth 콜백 처리
- KakaoCallback.jsx 컴포넌트 구현으로 카카오 인증 후 리다이렉트 처리
- URL 파라미터에서 토큰, 사용자 ID, 신규 사용자 여부 추출
- 토큰 저장 및 사용자 정보 조회 후 리다이렉트
- 백엔드의 KakaoOAuthCallbackController와 연동하여 인증 코드 처리 및 JWT 토큰 발급

3. 일반 회원가입 구현
- SignUp.jsx에서 단계별 회원가입 폼 구현
- 각 단계별 입력 필드 유효성 검사
- /api/v1/auth/signup 과 연동하여 회원가입 처리

4. 일반 로그인 구현
- Login.jsx에서 로그인 폼 구현
- /api/v1/auth/login 와 연동하여 로그인 처리
- JWT 토큰 저장 및 사용자 정보 조회
- 로그인 성공 시 리다이렉트